### PR TITLE
Allow for https addresses for Universal Search

### DIFF
--- a/Src/OpenSearchHandler.cpp
+++ b/Src/OpenSearchHandler.cpp
@@ -288,7 +288,7 @@ bool OpenSearchHandler::parseXml (const std::string& xmlFile, bool scanningDir)
    		 	info.imageData = parseImage(info.id, info.imageData);
    		 }    	
     }
-    else if(uriScheme != NULL && strcmp(uriScheme, "http") == 0) {
+    else if(uriScheme != NULL && ((strcmp(uriScheme, "http") == 0) || (strcmp(uriScheme, "https") == 0)) {
     	//It's a url to icon. Download the image. But we don't wait for the download to complete.
     	//So, the assumption here is that download will complete and file will be created in the specified path. If there is a problem then it will default to generic icon.
     	info.imageData = downloadIcon(info.imageData);


### PR DESCRIPTION
:Release Notes:
Add support for https addresses for Universal Search

:Detailed Notes:
Since all major search engines nowadays will allow searches via https it's good to have it available in Universal Search as well.

:Testing Performed:

:QA Notes:

:Issues Addressed:
Cannot use https addresses for Universal Search

Open-webOS-DCO-1.0-Signed-off-by: Herman van Hazendonk github.com@herrie.org
