### PR TITLE
luna-universalsearchmgr: Fix ACG permissions

### DIFF
--- a/files/sysbus/com.palm.universalsearch.perm.json
+++ b/files/sysbus/com.palm.universalsearch.perm.json
@@ -1,6 +1,11 @@
 {
     "com.palm.universalsearch": [
         "services",
-        "applications"
+        "applications",
+        "signals.all",
+        "settings",
+        "applications.internal",
+        "system",
+        "networking.internal"
     ]
 }


### PR DESCRIPTION
Since Universeal Search Manager is quite deeply integrated, it should be allowed to be accessed from additional groups.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>